### PR TITLE
fix(spinbot): Remove influxdb config

### DIFF
--- a/manifests/deploy.yml
+++ b/manifests/deploy.yml
@@ -109,8 +109,3 @@ data:
           - spinnaker/spinnaker.github.io
       - name: pull_request_closed_event_handler
       - name: pull_request_cherry_pick_event_handler
-
-    database:
-      influx:
-        host: 10.240.0.7
-        port: 8086


### PR DESCRIPTION
This database no longer exists, so spinnakerbot is just waiting for a connection that will never happen.