### PR TITLE
fix(spinbot): Remove extraneous comma and add imagepullpolicy

### DIFF
--- a/event/pull_request_cherry_pick_event_handler.py
+++ b/event/pull_request_cherry_pick_event_handler.py
@@ -44,7 +44,7 @@ class PullRequestCherryPickEventHandler(Handler):
         deprecation_message = (
             "Support for automating cherry picks is being removed from spinnakerbot "
             "in favor of the mergify backport command. To help with the transition, "
-            "I'll run the required command for you now, but in the future please ",
+            "I'll run the required command for you now, but in the future please "
             "run the mergify command directly."
         )
         mergify_command = "@Mergifyio backport release-{}.x".format(release)

--- a/manifests/deploy.yml
+++ b/manifests/deploy.yml
@@ -15,6 +15,7 @@ spec:
           containers:
           - name: spinbot
             image: gcr.io/spinnaker-marketplace/spinbot:master-latest
+            imagePullPolicy: Always
             volumeMounts:
             - name: config
               mountPath: /home/spinbot/.spinbot


### PR DESCRIPTION
I had an extra comma that was a syntax error; fix it.

Also, since we're not using a tag named ':latest' but are using a floating tag, we need to set ImagePullPolicy to Always, otherwise the job won't check to see if the tag has been udpated.