### PR TITLE
fix(spinbot): Reduce API usage of spinnakerbot

### DIFF
--- a/gh/util.py
+++ b/gh/util.py
@@ -10,8 +10,7 @@ def PullRequestRepo(issue):
     return '/'.join(issue.url.split('/')[-4:-2])
 
 def HasLabel(issue, name):
-    label = next((l for l in issue.get_labels() if l.name == name), None)
-    return label is not None
+    return name in map(lambda l : l.name, issue.labels)
 
 def RemoveLabel(gh, issue, name, create=True):
     if not HasLabel(issue, name):

--- a/policy/log_pull_request_policy.py
+++ b/policy/log_pull_request_policy.py
@@ -21,20 +21,13 @@ class LogPullRequestPolicy(Policy):
 
         repo = PullRequestRepo(o)
 
-        reviews = 0
-        for r in o.get_reviews():
-            reviews += 1
-
         self.monitoring_db.write('pull_request', { 
             'days_since_created': days_since_created,
             'days_since_updated': days_since_updated,
-            'review_comments': o.review_comments,
-            'reviews': reviews,
             'count': 1
         }, tags={ 
             'repo': repo, 
             'user': o.user.login,
-            'mergable_state': o.mergeable_state,
             'state': o.state
         })
 


### PR DESCRIPTION
* fix(spinbot): Reduce API usage of label filtering

  We're currently calling the API to get an issue's labels every time we want to check if it has a particular label. The labels are already on the object we have, so just use issue.labels instead of get_labels.

  Also minorly simplify the logic, which looked to be an attempt to be efficient by short-circuiting the check as soon as a label was found but ended up writing code that was complex and masked a real performance issue. (I'd rather iterate over a list that will probably have a length of 5 at most than make a network call.)

* fix(spinbot): Stop logging expensive fields on pull requests

  Before this change, we were making 2 API calls for every open PR we encountered:
  * One to /pulls/:pull_number to get the pull request to fill in the review_comments and mergeable_state fields that are not included in the /pulls list endpoint. (The client library handles noticing that we don't have a complete object and making a call to fill in the details, and also only makes a single call even though we use two fields)
  * One to /pulls/:pull_number/reviews to get all the reviews so we can count them.

  This leads to 2 * N requests every 5 minutes, where N is the total number of open pull requests across all repos. At some point recently as part of moving infrastructure to community-owned projects, the database where we're logging this monitoring was removed anyway so nobody is even looking this data (as it doesn't survive past a single run of spinnakerbot).

  While eventually we should either fix the monitoring so it actually goes somewhere, or just delete all this code, let's at least in the meantime stop logging things that are expensive. If we do turn back on logging, we can decide to either:
  * Replace these metrics with things available from the list endpoint
  * Pull the more expensive things into another job that runs less frequently. We need spinnakerbot to run frequently (for now) as it responds to user commands, but we could split it out so that it does some things frequently (respond to events) and other things less frequently (log expensive metrics).

  This PR just removes the most expensive metrics to greatly reduce the API usage.