### PR TITLE
perf(core): Reduce size of docker container and use cached build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM python:3
+FROM python:3-alpine
 
-RUN useradd -ms /bin/bash spinbot
+RUN adduser -D -S spinbot
 
 WORKDIR /usr/src/app
 
-COPY . .
-
-RUN chown -R spinbot *
+COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
+COPY . .
+
 USER spinbot
 
-CMD [ "./spinbot.py" ]
+ENTRYPOINT ["/usr/local/bin/python", "./spinbot.py" ]

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ init:
 	python3 -m pip install -r requirements.txt
 
 docker:
-	# Can only use 1 --tag (-t) tag via 'gcloud builds submit', otherwise last one wins.
 	gcloud builds submit . \
-		--project ${PROJECT} \
-		-t ${IMAGE}:${BRANCH}-latest
+      --config cloudbuild.yaml \
+      --project ${PROJECT} \
+      --substitutions=TAG_NAME=${BRANCH}-latest,_PROJECT=${PROJECT}
 
 .PHONY: init docker

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,15 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        docker pull gcr.io/${_PROJECT}/spinbot:$TAG_NAME || exit 0
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [
+      'build',
+      '-t', 'gcr.io/${_PROJECT}/spinbot:${TAG_NAME}',
+      '--cache-from', 'gcr.io/${_PROJECT}/spinbot:${TAG_NAME}',
+      '.'
+    ]
+images: ['gcr.io/${_PROJECT}/spinbot:${TAG_NAME}']

--- a/config.py
+++ b/config.py
@@ -34,7 +34,6 @@ def merge_single_arg_key(ctx, key, val):
         merge_single_arg_key(ctx.get(k, {}), key, val)
 
 def GetCtx():
-    ctx = {}
     with open(os.path.expanduser('~/.spinbot/config'), 'r') as f:
         ctx = yaml.safe_load(f)
 

--- a/event/__init__.py
+++ b/event/__init__.py
@@ -1,3 +1,3 @@
-from .handler_registry import Handlers, ConfigureHandlers
-from .executor import ProcessEvents
 from .args import AddArgs
+from .executor import ProcessEvents
+from .handler_registry import Handlers, ConfigureHandlers

--- a/event/command.py
+++ b/event/command.py
@@ -5,7 +5,6 @@ def GetCommands(text):
     lines = text.splitlines()
     for line in lines:
         line = line.strip()
-        # todo(lwander): parameterize
         if line.startswith('@spinnakerbot'):
             command = line[len('@spinnakerbot'):].replace(": :", "::").strip()
             if len(command) > 0:

--- a/event/executor.py
+++ b/event/executor.py
@@ -1,7 +1,8 @@
 import logging
 import traceback
-import event
 from datetime import datetime
+
+import event
 from .handler_registry import GetConfig
 
 dateformat = '%Y-%m-%d %H:%M:%S'
@@ -15,7 +16,7 @@ def ProcessEvents(g, s):
     start_at = config.get('start_at')
 
     if start_at is None:
-        start_at = s.load('start_at');
+        start_at = s.load('start_at')
 
     if start_at is None:
         start_at = datetime.now()
@@ -32,11 +33,9 @@ def ProcessEvents(g, s):
         for h in event.Handlers():
             if h.handles(e):
                 logging.info('Handling {} with {}'.format(e, h))
-                err = None
                 try:
                     h.handle(g, e)
                 except Exception as _err:
                     logging.warn('Failure handling {} with {} due to {}: {}'.format(
                             e, h, _err, traceback.format_exc()
                     ))
-                    err = _err

--- a/event/filetype_check_pull_request_handler.py
+++ b/event/filetype_check_pull_request_handler.py
@@ -1,6 +1,5 @@
 from .handler import Handler
-from .pull_request_event import GetBaseBranch, GetPullRequest, GetTitle, GetRepo
-from gh import ReleaseBranchFor, ParseCommitMessage
+from .pull_request_event import GetPullRequest, GetRepo
 
 format_message = ('We prefer that non-test backend code be written in Java or Kotlin, rather ' +
         'than Groovy. The following files have been added and written in Groovy:\n\n' +

--- a/event/handler.py
+++ b/event/handler.py
@@ -1,5 +1,7 @@
 import logging
+
 from .handler_registry import RegisterHandler, GetHandlerConfig
+
 
 class Handler(object):
     def __init__(self):

--- a/event/handler_registry.py
+++ b/event/handler_registry.py
@@ -1,6 +1,5 @@
 import importlib
 import logging
-from os import listdir
 from os.path import isfile, join, dirname, realpath
 
 handlers = []

--- a/event/issue_comment_assign_handler.py
+++ b/event/issue_comment_assign_handler.py
@@ -1,7 +1,7 @@
-from gh import AddLabel, RemoveLabel
-from .handler import Handler
 from .command import GetCommands
+from .handler import Handler
 from .issue_event import GetIssue, GetRepo
+
 
 class IssueCommentAssignHandler(Handler):
     def __init__(self):

--- a/event/label_issue_comment_event_handler.py
+++ b/event/label_issue_comment_event_handler.py
@@ -1,7 +1,8 @@
 from gh import AddLabel, RemoveLabel
-from .handler import Handler
 from .command import GetCommands
+from .handler import Handler
 from .issue_event import GetIssue
+
 
 class LabelIssueCommentEventHandler(Handler):
     def __init__(self):

--- a/event/log_event_handler.py
+++ b/event/log_event_handler.py
@@ -1,4 +1,3 @@
-import re
 from .handler import Handler
 
 class LogEventHandler(Handler):
@@ -9,12 +8,6 @@ class LogEventHandler(Handler):
         return True
 
     def handle(self, g, event):
-        company = event.actor.company
-        if not company:
-            company = "unknown"
-        else:
-            company = re.sub(r'\W+', '', company).lower()
-
         self.logging.info('{} ({}): @{} -> {}'.format(event.repo.name, event.created_at, event.actor.login, event.type))
         if self.config.get('payload'):
             self.logging.info('  {}'.format(event.payload))

--- a/event/master_branch_pull_request_handler.py
+++ b/event/master_branch_pull_request_handler.py
@@ -1,6 +1,6 @@
+from gh import ParseCommitMessage, FormatCommit
 from .handler import Handler
-from .pull_request_event import GetBaseBranch, GetPullRequest, GetTitle, GetRepo
-from gh import ReleaseBranchFor, ParseCommitMessage, FormatCommit
+from .pull_request_event import GetBaseBranch, GetPullRequest, GetRepo
 
 format_message = ('The following commits need their title changed:\n\n{}\n\n' +
     'Please format your commit title into the form: \n\n' +

--- a/event/pull_request_cherry_pick_event_handler.py
+++ b/event/pull_request_cherry_pick_event_handler.py
@@ -1,6 +1,5 @@
-from gh import AddLabel, RemoveLabel, ParseCommitMessage
-from .handler import Handler
 from .command import GetCommands
+from .handler import Handler
 from .pull_request_event import GetPullRequest, GetRepo
 
 invalid_command_format = ("You must specify exactly 1 release to cherry-pick " +

--- a/event/pull_request_closed_event_handler.py
+++ b/event/pull_request_closed_event_handler.py
@@ -1,6 +1,7 @@
-from gh import ParseReleaseBranch, ParseCommitMessage, AddLabel
-from .pull_request_event import GetBaseBranch, GetPullRequest, GetRepo
+from gh import ParseReleaseBranch, AddLabel
 from .handler import Handler
+from .pull_request_event import GetBaseBranch, GetPullRequest, GetRepo
+
 
 class PullRequestClosedEventHandler(Handler):
     def __init__(self):

--- a/event/pull_request_message_handler.py
+++ b/event/pull_request_message_handler.py
@@ -1,6 +1,5 @@
 from .handler import Handler
-from .pull_request_event import GetBaseBranch, GetPullRequest, GetTitle, GetRepo
-from gh import ReleaseBranchFor, ParseCommitMessage
+from .pull_request_event import GetPullRequest, GetRepo
 
 bad_contents = (['### Instructions (that you should delete before submitting):', 
     'We prefer small, well tested pull requests.'])

--- a/event/release_branch_pull_request_handler.py
+++ b/event/release_branch_pull_request_handler.py
@@ -1,6 +1,6 @@
-from .handler import Handler
-from .pull_request_event import GetBaseBranch, GetPullRequest, GetTitle, GetRepo
 from gh import ReleaseBranchFor, ParseCommitMessage, FormatCommit
+from .handler import Handler
+from .pull_request_event import GetBaseBranch, GetPullRequest, GetRepo
 
 format_message = ('Features cannot be merged into release branches. The following commits ' +
     'are not tagged as one of "{}":\n\n{}\n\n' +

--- a/gh/__init__.py
+++ b/gh/__init__.py
@@ -1,3 +1,3 @@
 from .client import Client
-from .util import ObjectType, IssueRepo, HasLabel, AddLabel, RemoveLabel, PullRequestRepo
+from .util import ObjectType, IssueRepo, HasLabel, AddLabel, RemoveLabel
 from .conventions import ReleaseBranchFor, ParseCommitMessage, ParseReleaseBranch, FormatCommit

--- a/gh/client.py
+++ b/gh/client.py
@@ -112,7 +112,6 @@ class ETagSupport:
         return url.endswith('/events')
 
     def request(self, verb, url, input, headers):
-        previous_etag = None
         if self.can_use_etag(url):
             previous_etag = self.storage.load("ETag:%s" % url)
             self.logging.info("---> %s %s (ETag: %s)" % (verb, url, previous_etag))

--- a/gh/util.py
+++ b/gh/util.py
@@ -6,9 +6,6 @@ logging = logging.getLogger('github_util')
 def IssueRepo(issue):
     return '/'.join(issue.url.split('/')[-4:-2])
 
-def PullRequestRepo(issue):
-    return '/'.join(issue.url.split('/')[-4:-2])
-
 def HasLabel(issue, name):
     return name in map(lambda l : l.name, issue.labels)
 

--- a/storage/gcs_storage.py
+++ b/storage/gcs_storage.py
@@ -48,8 +48,6 @@ class GcsStorage(Storage):
         contents = '{}'
         if b:
             contents = b.download_as_string()
-        else:
-            b = self.bucket.blob(self.path)
 
         props = yaml.safe_load(contents)
         if props is None:


### PR DESCRIPTION
* chore(core): Clean up some more unused code

  Now that the monitoring code is gone, there was some more unused code that we should delete. This commit removes a few unused variables/functions and cleans up the imports.

* perf(core): Reduce size of docker container and use cached build

  We can greatly reduce the size of the spinnakerbot image by using an alpine base image. This reduces the image size from ~340MB to ~40MB.

  Also, move the 'pip install' command before we copy over the whole app. This greatly speeds up local docker builds as we don't need to re-install all requirements if they haven't changed since the last build. Also change the GCB build to cache from the prior build on the same branch so that it gets the same advantage. (This requires pulling it out into a cloudbuild.yaml file.)

  Remove the chown command; one of the advantages of not running as root is that the app doesn't have permission to write to its source code; chown'ing all the source to be owned by the app defeats this.

  Finally, change CMD to ENTRYPOINT as we don't need to go through a shell to execute this python script.