### PR TITLE
perf(core): A few more minor perf fixes to spinnakerbot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+venv

--- a/config.py
+++ b/config.py
@@ -1,8 +1,11 @@
 import argparse
 import os
+
 import yaml
+
 import event
 import policy
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Spinbot CLI options')

--- a/event/executor.py
+++ b/event/executor.py
@@ -12,6 +12,7 @@ def ProcessEvents(g, s):
     enabled = config.get('enabled', True)
     if enabled is not None and not enabled:
         return
+    repos = config.get('repos', [])
 
     start_at = config.get('start_at')
 
@@ -26,7 +27,7 @@ def ProcessEvents(g, s):
     newest_event = start_at
 
     logging.info('Processing events, starting at {}'.format(start_at))
-    for e in g.events_since(start_at):
+    for e in g.events_since(start_at, repos):
         if e.created_at > newest_event:
             newest_event = e.created_at
             s.store('start_at', newest_event.strftime(dateformat))

--- a/event/executor.py
+++ b/event/executor.py
@@ -36,6 +36,6 @@ def ProcessEvents(g, s):
                 try:
                     h.handle(g, e)
                 except Exception as _err:
-                    logging.warn('Failure handling {} with {} due to {}: {}'.format(
+                    logging.warning('Failure handling {} with {} due to {}: {}'.format(
                             e, h, _err, traceback.format_exc()
                     ))

--- a/event/handler_registry.py
+++ b/event/handler_registry.py
@@ -9,7 +9,7 @@ def ConfigureHandlers(_conf):
     conf.update(_conf)
     handlers = _conf.get('handlers')
     if not handlers:
-        logging.warn('No handlers registered')
+        logging.warning('No handlers registered')
         return
 
     dir_path = dirname(realpath(__file__))
@@ -20,7 +20,7 @@ def ConfigureHandlers(_conf):
             logging.info('Registering {}'.format(h))
             importlib.import_module('event.{}'.format(name))
         else:
-            logging.warn('{} is not a valid handler name, ignoring it.'.format(f))
+            logging.warning('{} is not a valid handler name, ignoring it.'.format(f))
 
 def GetConfig():
     return conf

--- a/event/issue_event.py
+++ b/event/issue_event.py
@@ -6,7 +6,7 @@ def GetIssue(g, event):
     repo = '/'.join(url.split('/')[-4:-2])
     number = int(url.split('/')[-1])
 
-    if repo == None or number == None:
+    if repo is None or number is None:
         return None
 
     return g.get_issue(repo, number)

--- a/event/pull_request_closed_event_handler.py
+++ b/event/pull_request_closed_event_handler.py
@@ -1,3 +1,5 @@
+import logging
+
 from gh import ParseReleaseBranch, AddLabel
 from .handler import Handler
 from .pull_request_event import GetBaseBranch, GetPullRequest, GetRepo
@@ -14,7 +16,7 @@ class PullRequestClosedEventHandler(Handler):
     def handle(self, g, event):
         pull_request = GetPullRequest(g, event)
         if not pull_request:
-            log.warn('Unable to determine pull request for {}'.format(event))
+            logging.warning('Unable to determine pull request for {}'.format(event))
             return
 
         self.label_release(g, event, pull_request)
@@ -25,7 +27,7 @@ class PullRequestClosedEventHandler(Handler):
 
         base_branch = GetBaseBranch(event)
         release_branch = ParseReleaseBranch(base_branch)
-        if release_branch != None:
+        if release_branch is not None:
             return self.target_release(g, pull_request, release_branch)
 
         repo = GetRepo(event)

--- a/event/pull_request_event.py
+++ b/event/pull_request_event.py
@@ -17,14 +17,14 @@ def GetRepo(event):
 def GetPullRequest(g, event):
     repo = GetRepo(event)
     number = event.payload.get('number', event.payload.get('issue', {}).get('number'))
-    if repo == None or number == None:
+    if repo is None or number is None:
         url = event.payload.get('issue', {}).get('url')
         if not url:
             return None
 
         number = int(url.split('/')[-1])
 
-        if repo == None or number == None:
+        if repo is None or number is None:
             return None
 
     return g.get_pull_request(repo, number)

--- a/gh/__init__.py
+++ b/gh/__init__.py
@@ -1,4 +1,4 @@
 from .client import Client
 from .conventions import ReleaseBranchFor, ParseCommitMessage, \
   ParseReleaseBranch, FormatCommit
-from .util import ObjectType, IssueRepo, HasLabel, AddLabel, RemoveLabel
+from .util import IssueRepo, HasLabel, AddLabel, RemoveLabel

--- a/gh/__init__.py
+++ b/gh/__init__.py
@@ -1,3 +1,4 @@
 from .client import Client
+from .conventions import ReleaseBranchFor, ParseCommitMessage, \
+  ParseReleaseBranch, FormatCommit
 from .util import ObjectType, IssueRepo, HasLabel, AddLabel, RemoveLabel
-from .conventions import ReleaseBranchFor, ParseCommitMessage, ParseReleaseBranch, FormatCommit

--- a/gh/client.py
+++ b/gh/client.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
-import github
-import logging
 import heapq
+import logging
 import os
+
+import github
+
 
 class Client(object):
     def __init__(self, config, storage):

--- a/gh/client.py
+++ b/gh/client.py
@@ -13,7 +13,6 @@ class Client(object):
         self.username = self.get_username(config)
         self.g = github.Github(self.token)
         self.storage = storage
-        self._repos = config['repos']
         self._repo_objects = dict()
         self.logging = logging.getLogger('github_client_wrapper')
 
@@ -58,17 +57,15 @@ class Client(object):
             self._repo_objects[r] = self.g.get_repo(r)
         return self._repo_objects[r]
 
-    def issues(self):
-        for r in self._repos:
-            issues = 0
+    def issues(self, repos):
+        for r in repos:
             self.logging.info('Reading issues from {}'.format(r))
             for i in self.get_repo(r).get_issues():
-                issues += 1
                 yield i
 
-    def events_since(self, date):
+    def events_since(self, date, repos):
         return heapq.merge(
-                *[ reversed(list(self._events_since_repo_iter(date, r))) for r in self._repos ],
+                *[ reversed(list(self._events_since_repo_iter(date, r))) for r in repos ],
                 key=lambda e: e.created_at
         )
 

--- a/gh/client.py
+++ b/gh/client.py
@@ -58,18 +58,6 @@ class Client(object):
             self._repo_objects[r] = self.g.get_repo(r)
         return self._repo_objects[r]
 
-    def repos(self):
-        for r in self._repos:
-            yield self.get_repo(r)
-
-    def pull_requests(self):
-        for r in self._repos:
-            pulls = 0
-            self.logging.info('Reading pull requests from {}'.format(r))
-            for i in self.get_repo(r).get_pulls():
-                pulls += 1
-                yield i
-
     def issues(self):
         for r in self._repos:
             issues = 0

--- a/gh/util.py
+++ b/gh/util.py
@@ -1,5 +1,9 @@
-import github
 import logging
+
+import github
+import github.Issue
+import github.PullRequest
+import github.Repository
 
 logging = logging.getLogger('github_util')
 
@@ -18,7 +22,7 @@ def RemoveLabel(gh, issue, name, create=True):
 
     label = gh.get_label(IssueRepo(issue), name, create=create)
     if label is None:
-        logging.warn(
+        logging.warning(
             'Label {} exists on the issue but was not found'.format(name)
         )
         return

--- a/gh/util.py
+++ b/gh/util.py
@@ -1,10 +1,5 @@
 import logging
 
-import github
-import github.Issue
-import github.PullRequest
-import github.Repository
-
 logging = logging.getLogger('github_util')
 
 def IssueRepo(issue):
@@ -41,13 +36,3 @@ def AddLabel(gh, issue, name, create=True):
         )
         return
     issue.add_to_labels(label)
-
-def ObjectType(o):
-    if isinstance(o, github.Issue.Issue) and o.html_url.split('/')[-2] == 'issues':
-        return 'issue'
-    if isinstance(o, github.PullRequest.PullRequest):
-        return 'pull_request'
-    elif isinstance(o, github.Repository.Repository):
-        return 'repository'
-    else:
-        return None

--- a/manifests/deploy.yml
+++ b/manifests/deploy.yml
@@ -46,6 +46,28 @@ data:
   config: |
     github:
       token_path: /home/spinbot/github/token
+
+    logging:
+      level: INFO
+
+    storage:
+      gcs:
+        bucket: spinnaker-bot-cache
+        project: spinnaker-build
+        path: cache
+        json_path: /home/spinbot/credentials/account.json
+
+    policy:
+      repos:
+      - spinnaker/spinnaker
+      - spinnaker/spinnaker.github.io
+      - spinnaker/deck-kayenta
+      - spinnaker/kayenta
+      - spinnaker/keel
+      policies:
+      - name: stale_issue_policy
+
+    event:
       repos:
       - spinnaker/spinnaker
       - spinnaker/spinnaker.github.io
@@ -65,22 +87,6 @@ data:
       - spinnaker/halyard
       - spinnaker/spin
       - spinnaker/kork
-
-    logging:
-      level: INFO
-
-    storage:
-      gcs:
-        bucket: spinnaker-bot-cache
-        project: spinnaker-build
-        path: cache
-        json_path: /home/spinbot/credentials/account.json
-
-    policy:
-      policies:
-      - name: stale_issue_policy
-
-    event:
       handlers:
       - name: label_issue_comment_event_handler
       - name: issue_comment_assign_handler

--- a/policy/__init__.py
+++ b/policy/__init__.py
@@ -1,3 +1,3 @@
-from .policy_registry import ConfigurePolicies, Policies
-from .executor import ApplyPolicies
 from .args import AddArgs
+from .executor import ApplyPolicies
+from .policy_registry import ConfigurePolicies, Policies

--- a/policy/executor.py
+++ b/policy/executor.py
@@ -13,8 +13,9 @@ def ApplyPolicies(g):
     if enabled is not None and not enabled:
         return
 
-    logging.info('Processing issues, repos')
-    for i in g.issues():
+    repos = config.get('repos', [])
+    logging.info('Processing issues')
+    for i in g.issues(repos):
         for p in policy.Policies():
             if p.applies(i):
                 err = None

--- a/policy/executor.py
+++ b/policy/executor.py
@@ -1,4 +1,3 @@
-import itertools
 import logging
 import traceback
 
@@ -15,7 +14,7 @@ def ApplyPolicies(g):
         return
 
     logging.info('Processing issues, repos')
-    for i in itertools.chain(*[g.issues(), g.pull_requests(), g.repos()]):
+    for i in g.issues():
         for p in policy.Policies():
             if p.applies(i):
                 err = None

--- a/policy/executor.py
+++ b/policy/executor.py
@@ -1,9 +1,12 @@
-import policy
-import traceback
-import logging
 import itertools
+import logging
+import traceback
+
 import github
+
+import policy
 from .policy_registry import GetConfig
+
 
 def ApplyPolicies(g):
     config = GetConfig()
@@ -19,14 +22,14 @@ def ApplyPolicies(g):
                 try:
                     p.apply(g, i)
                 except Exception as _err:
-                    logging.warn('Failure applying {} to {} due to {}: {}'.format(
+                    logging.warning('Failure applying {} to {} due to {}: {}'.format(
                             p, i, _err, traceback.format_exc()
                     ))
                     err = _err
 
-                if err is not None and isinstance(err, github.GithubException.GithubException):
+                if err is not None and isinstance(err, github.GithubException):
                   if err.status == 403:
                     # we triggered abuse protection, time to shutdown
-                    logging.warn('Abuse protection triggered. Shutting down early.')
+                    logging.warning('Abuse protection triggered. Shutting down early.')
                     return
 

--- a/policy/policy.py
+++ b/policy/policy.py
@@ -1,5 +1,7 @@
 import logging
 
+import github.Issue
+
 from .policy_registry import RegisterPolicy, GetPolicyConfig
 
 
@@ -15,9 +17,9 @@ class Policy(object):
         name = ''.join(map(lambda c: '_' + c.lower() if c.isupper() else c, name)).strip('_')
         return name
 
-    def applies(self, o):
+    def applies(self, o: github.Issue.Issue):
         raise NotImplementedError('applies not implemented')
 
-    def apply(self, g, o):
+    def apply(self, g, o: github.Issue.Issue):
         raise NotImplementedError('apply not implemented')
 

--- a/policy/policy.py
+++ b/policy/policy.py
@@ -1,5 +1,7 @@
 import logging
+
 from .policy_registry import RegisterPolicy, GetPolicyConfig
+
 
 class Policy(object):
     def __init__(self):

--- a/policy/policy_registry.py
+++ b/policy/policy_registry.py
@@ -9,7 +9,7 @@ def ConfigurePolicies(_conf):
     conf.update(_conf)
     policies = _conf.get('policies')
     if policies is None:
-        logging.warn('{} no policies registered')
+        logging.warning('{} no policies registered')
         return
 
     dir_path = dirname(realpath(__file__))
@@ -20,7 +20,7 @@ def ConfigurePolicies(_conf):
             logging.info('Registering {}'.format(p))
             importlib.import_module('policy.{}'.format(name))
         else:
-            logging.warn('{} is not a valid policy name, ignoring it.'.format(f))
+            logging.warning('{} is not a valid policy name, ignoring it.'.format(f))
 
 def GetPolicyConfig(name):
     policy = next((p for p in conf.get('policies', []) if p.get('name') == name), {})

--- a/policy/stale_issue_policy.py
+++ b/policy/stale_issue_policy.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 
-from gh import HasLabel, AddLabel, ObjectType
+import github.Issue
+
+from gh import HasLabel, AddLabel
 from .policy import Policy
 
 
@@ -14,10 +16,10 @@ class StaleIssuePolicy(Policy):
         if not self.stale_days:
             self.stale_days = 45
 
-    def applies(self, o):
-        return ObjectType(o) == 'issue'
+    def applies(self, o: github.Issue.Issue):
+        return o.html_url.split('/')[-2] == 'issues'
 
-    def apply(self, g, o):
+    def apply(self, g, o: github.Issue.Issue):
         days_since_created = None
         days_since_updated = None
         now = datetime.now()

--- a/policy/stale_issue_policy.py
+++ b/policy/stale_issue_policy.py
@@ -1,6 +1,8 @@
-from gh import ObjectType, IssueRepo, HasLabel, AddLabel
 from datetime import datetime
+
+from gh import HasLabel, AddLabel, ObjectType
 from .policy import Policy
+
 
 class StaleIssuePolicy(Policy):
     def __init__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+google
 pygithub>=1.40a
 pyyaml
 google-cloud-storage

--- a/spinbot.py
+++ b/spinbot.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
 import logging
-import gh
-import storage
+
 import event
+import gh
 import policy
+import storage
 from config import GetCtx
+
 
 def create_client(ctx, storage):
     return gh.Client(ctx.get('github', {}), storage)

--- a/storage/build_storage.py
+++ b/storage/build_storage.py
@@ -1,5 +1,6 @@
-from .local_storage import LocalStorage
 from .gcs_storage import GcsStorage
+from .local_storage import LocalStorage
+
 
 def BuildStorage(props):
     local = props.get('local', None)

--- a/storage/gcs_storage.py
+++ b/storage/gcs_storage.py
@@ -1,8 +1,11 @@
 import os
+
 import yaml
 from google.cloud import storage
 from google.oauth2 import service_account
+
 from .storage import Storage
+
 
 class GcsStorage(Storage):
     def __init__(self, bucket, path, project=None, json_path=None):

--- a/storage/local_storage.py
+++ b/storage/local_storage.py
@@ -1,6 +1,9 @@
 import os
+
 import yaml
+
 from .storage import Storage
+
 
 class LocalStorage(Storage):
     def __init__(self, path):


### PR DESCRIPTION
* fix(core): Fix some lint warnings

  * logging.warn is deprecated; use logging.warning
  * The google package was depended on but was not in requirements, though was being transitively included
  * Add venv to .gitignore, as IntelliJ uses this to create a virtual environment when you set up python support

* perf(core): Remove iteration over repos and PRs

  After removing the metrics code, the only remaining handler looks at issues only, so remove the iteration over repos and PRs in the policy code. (Note that we *do* still look at PRs in the event code, such as to respond to cherry picks and to look for new PRs writing groovy code---but we don't do anything with the result of listing all PRs in the repo.)

  This removes a bunch of calls to the API where we are just throwing away the result.

* perf(core): Only look for issues in repos that allow issues

  Most of our repos don't allow issues, so we're wasting our time polling every few minutes for issues in these repos. (And it's not always a cheap call as the issues endpoint also returns PRs which we filter on the client side.)

  Allow the event handler and policy handler to separately configure which repos to look at; the event handler will look at all repos, but the policy handler (which now only cares about issues) will only look at repos with issues enabled.