### PR TITLE
feat(cloudRun): Make SpinBot run as a webserver, and thus work in a Cloud Run environment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 .idea
 venv
+
+*.iml
+spinbot.json
+*.http
+
+__pycache_/
+**/*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3-alpine
+FROM python:3-slim
 
-RUN adduser -D -S spinbot
+RUN adduser --disabled-login --system spinbot
 
 WORKDIR /usr/src/app
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT=spinnaker-marketplace
+PROJECT=spinnaker-community
 IMAGE=gcr.io/${PROJECT}/spinbot
 
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)

--- a/config.py
+++ b/config.py
@@ -37,7 +37,7 @@ def merge_single_arg_key(ctx, key, val):
         merge_single_arg_key(ctx.get(k, {}), key, val)
 
 def GetCtx():
-    with open(os.path.expanduser('~/.spinbot/config'), 'r') as f:
+    with open(os.path.abspath('config/config.yaml'), 'r') as f:
         ctx = yaml.safe_load(f)
 
     args = parse_args()

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,68 @@
+github:
+  token: "secret:spinnaker-community/spinbot-gh-token#latest"
+
+logging:
+  level: INFO
+
+storage:
+  gcs:
+    bucket: spinbot-cache
+    project: spinnaker-community
+    path: cache
+
+policy:
+  repos:
+    - spinnaker/spinnaker
+    - spinnaker/spinnaker.github.io
+    - spinnaker/deck-kayenta
+    - spinnaker/kayenta
+    - spinnaker/keel
+  policies:
+    - name: stale_issue_policy
+
+event:
+  repos:
+    - spinnaker/spinnaker
+    - spinnaker/spinnaker.github.io
+    - spinnaker/clouddriver
+    - spinnaker/deck
+    - spinnaker/deck-kayenta
+    - spinnaker/echo
+    - spinnaker/fiat
+    - spinnaker/front50
+    - spinnaker/gate
+    - spinnaker/igor
+    - spinnaker/kayenta
+    - spinnaker/keel
+    - spinnaker/spinnaker-monitoring
+    - spinnaker/orca
+    - spinnaker/rosco
+    - spinnaker/halyard
+    - spinnaker/spin
+    - spinnaker/kork
+  handlers:
+    - name: label_issue_comment_event_handler
+    - name: issue_comment_assign_handler
+    - name: log_event_handler
+      config:
+        payload: false
+    - name: pull_request_message_handler
+    - name: filetype_check_pull_request_handler
+      config:
+        omit_repos:
+          - spinnaker/spinnaker
+          - spinnaker/spinnaker.github.io
+          - spinnaker/deck
+          - spinnaker/spin
+    - name: release_branch_pull_request_handler
+      config:
+        omit_repos:
+          - spinnaker/spinnaker
+          - spinnaker/spinnaker.github.io
+    - name: master_branch_pull_request_handler
+      config:
+        omit_repos:
+          - spinnaker/spinnaker
+          - spinnaker/spinnaker.github.io
+    - name: pull_request_closed_event_handler
+    - name: pull_request_cherry_pick_event_handler

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 google
 pygithub>=1.40a
 pyyaml
+google-cloud-secret-manager
 google-cloud-storage

--- a/secrets/__init__.py
+++ b/secrets/__init__.py
@@ -1,0 +1,1 @@
+from .gcp_secrets import GcpSecretsManager

--- a/secrets/gcp_secrets.py
+++ b/secrets/gcp_secrets.py
@@ -1,0 +1,19 @@
+import os
+
+from google.cloud import secretmanager
+from google.oauth2 import service_account
+
+class GcpSecretsManager():
+    def __init__(self, json_path=None):
+        if json_path is None:
+            self.client = secretmanager.SecretManagerServiceClient()
+        else:
+            json_path = os.path.expanduser(json_path)
+            credentials = service_account.Credentials.from_service_account_file(json_path)
+            self.client = secretmanager.SecretManagerServiceClient(credentials=credentials)
+
+    def access_secret(self, project, secret_id, version):
+        name = self.client.secret_version_path(project, secret_id, version)
+        response = self.client.access_secret_version(name)
+        return response.payload.data.decode("utf-8")
+

--- a/spinbot.py
+++ b/spinbot.py
@@ -1,19 +1,66 @@
 #!/usr/bin/env python3
 
-import logging
-
 import event
 import gh
+import http
+import logging
+import os
 import policy
 import storage
+import sys
+import time
+
 from config import GetCtx
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from io import BytesIO
+
+
+class SimpleServer(HTTPServer):
+    def __init__(self, server_address, handler):
+        super().__init__(server_address, handler)
+        self.ctx = GetCtx()
+        setup_logging(self.ctx)
+        setup_events(self.ctx)
+        setup_policies(self.ctx)
+
+        self.storage = create_storage(self.ctx)
+        self.github_client = create_client(self.ctx, self.storage)
+
+
+class SimpleHandler(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/plain')
+        self.end_headers()
+        b = bytes("working!", "UTF-8")
+        self.wfile.write(b)
+
+    def do_POST(self):
+        try:
+            event.ProcessEvents(self.server.github_client, self.server.storage)
+            policy.ApplyPolicies(self.server.github_client)
+            logging.info('...done')
+            self.send_response(200)
+            self.send_header('Content-type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(bytes("done!", "UTF-8"))
+        except:
+            e = sys.exc_info()[0]
+            logging.error(e)
+            self.send_response(500)
+            self.send_header('Content-type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(bytes("something went wrong", "UTF-8"))
 
 
 def create_client(ctx, storage):
     return gh.Client(ctx.get('github', {}), storage)
 
+
 def create_storage(ctx):
     return storage.BuildStorage(ctx.get('storage', {}))
+
 
 def setup_logging(ctx):
     lctx = ctx.get('logging', {})
@@ -24,25 +71,24 @@ def setup_logging(ctx):
         level=level
     )
 
+
 def setup_events(ctx):
     event.ConfigureHandlers(ctx.get('event', {}))
+
 
 def setup_policies(ctx):
     policy.ConfigurePolicies(ctx.get('policy', {}))
 
-def main():
-    ctx = GetCtx()
-
-    setup_logging(ctx)
-    setup_events(ctx)
-    setup_policies(ctx)
-
-    storage = create_storage(ctx)
-    github_client = create_client(ctx, storage)
-
-    event.ProcessEvents(github_client, storage)
-    policy.ApplyPolicies(github_client)
-    logging.info('...done')
 
 if __name__ == '__main__':
-    main()
+    port = os.environ.get('PORT', "8080")
+    port = int(port)
+
+    httpd = SimpleServer(('', port), SimpleHandler)
+    print(time.asctime(), "Server Starts - %s:%s" % ('', port))
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    httpd.server_close()
+    print(time.asctime(), "Server Stops - %s:%s" % ("", port))


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/5443

Before we go any further, this is me when doing Python development:
![unnamed](https://user-images.githubusercontent.com/13141550/79231189-b139ab80-7e33-11ea-859a-1b4ac1fa44fb.png)

This PR changes Spinbot from a CLI to a webserver, callable on a CRON schedule.

There are a few advantages to this PR:

1. Config no longer lives hidden in a config file that lives in the cluster.
1. No need to have long-lived GCP credentials (uses AppDefault Creds)
1. GH token now lives in GCP Secret Manager (this PR includes integration with that system - the change from `python:3-alpine` to `python:3-slim` was because the GRPC libraries needed something that wasn't in the alpine container).
1. Only authenticated callers can GET or POST on this job (not open to the public, in case you were worried)

I have this container running successfully as a Cloud Run service in `spinnaker-community`. A successful POST took 106s to complete, well within the 300s default timeout for Cloud Run requests.

Upon submission:

1. I will recreate the Cloud Build trigger to build and deploy the container upon push to `master` ([similar to spinnaker/stats](https://github.com/spinnaker/stats/blob/master/cloudbuild-deploy-staging.yaml))
1. I'll setup a Cloud Schedule to POST to this job every 10 minutes, which I think is the current frequency.
1. Turn down the k8s cluster that's currently running spinnakerbot