### PR TITLE
fix(commands): allow commands with spaces

### DIFF
--- a/event/command.py
+++ b/event/command.py
@@ -1,3 +1,12 @@
+import re
+
+
+# Returns the command in a given text. The commands are matched as tokens
+# between spaces, between single quotes or between double quotes.
+# For example:
+#    @spinnakerbot add-label foo "bar baz"
+# will return a generator with three commands:
+#    ['do-something', 'foo', 'bar baz']
 def GetCommands(text):
     if not text:
         return None
@@ -8,4 +17,6 @@ def GetCommands(text):
         if line.startswith('@spinnakerbot'):
             command = line[len('@spinnakerbot'):].replace(": :", "::").strip()
             if len(command) > 0:
-                yield command.split()
+                tokens = re.split("\ |\"(.*)\"|'(.*)'", command)
+                yield [t for t in tokens if t is not None and t != ""]
+


### PR DESCRIPTION
This change allows commands to contain spaces whenever quotes are used.
This will allow adding labels that contain spaces, not possible before.

For a quick test you can run the following snippet from the root of the
project:

```
$ python <<EOF
from event.command import GetCommands
for command in GetCommands("@spinnakerbot do-something foo 'bar baz'"):
  print(command)
EOF
```
```
['do-something', 'foo', 'bar baz']
```

Fixes https://github.com/spinnaker/spinnaker/issues/5260