### PR TITLE
feat(cherry-pick): add 'backport' as a recongized cherry-pick command

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -66,3 +66,4 @@ event:
           - spinnaker/spinnaker
           - spinnaker/spinnaker.github.io
     - name: pull_request_closed_event_handler
+    - name: pull_request_cherry_pick_event_handler

--- a/event/pull_request_cherry_pick_event_handler.py
+++ b/event/pull_request_cherry_pick_event_handler.py
@@ -41,10 +41,8 @@ class PullRequestCherryPickEventHandler(Handler):
             pull_request.create_issue_comment(not_merged)
 
         deprecation_message = (
-            "Support for automating cherry picks is being removed from spinnakerbot "
-            "in favor of the mergify backport command. To help with the transition, "
-            "I'll run the required command for you now, but in the future please "
-            "run the mergify command directly."
+            "Until [Mergify allows anyone to backport](https://github.com/Mergifyio/mergify-engine/issues/1070) PRs,"
+            "I'll run the required command for you now"
         )
         mergify_command = "@Mergifyio backport release-{}.x".format(release)
         pull_request.create_issue_comment(deprecation_message)

--- a/event/pull_request_cherry_pick_event_handler.py
+++ b/event/pull_request_cherry_pick_event_handler.py
@@ -27,7 +27,7 @@ class PullRequestCherryPickEventHandler(Handler):
             return
 
         for command in GetCommands(event.payload.get('comment', {}).get('body')):
-            if command[0] in ['cherry-pick', ':cherries::pick:']:
+            if command[0] in ['cherry-pick', ':cherries::pick:', 'backport']:
                 if len(command) != 2:
                     pull_request.create_issue_comment(invalid_command_format)
                     return

--- a/event/pull_request_cherry_pick_event_handler.py
+++ b/event/pull_request_cherry_pick_event_handler.py
@@ -1,0 +1,53 @@
+from .command import GetCommands
+from .handler import Handler
+from .pull_request_event import GetPullRequest, GetRepo
+
+invalid_command_format = ("You must specify exactly 1 release to cherry-pick " +
+        "this commit into. For example:\n\n" +
+        "> @spinnakerbot cherry-pick 1.10")
+
+not_merged = "Only merged PRs can be cherry picked into a release branch"
+
+class PullRequestCherryPickEventHandler(Handler):
+    def __init__(self):
+        super().__init__()
+        self.omit_repos = self.config.get('omit_repos', [])
+
+    def handles(self, event):
+        return (event.type == 'IssueCommentEvent'
+            and (event.payload.get('action') == 'created'
+                or event.payload.get('action') == 'edited'))
+
+    def handle(self, g, event):
+        # avoid fetching until needed
+        pull_request = None
+        repo = GetRepo(event)
+        if repo in self.omit_repos:
+            self.logging.info('Skipping {} because it\'s in omitted repo {}'.format(event, repo))
+            return
+
+        for command in GetCommands(event.payload.get('comment', {}).get('body')):
+            if command[0] in ['cherry-pick', ':cherries::pick:']:
+                if len(command) != 2:
+                    pull_request.create_issue_comment(invalid_command_format)
+                    return
+                release = command[1]
+                if pull_request is None:
+                    pull_request = GetPullRequest(g, event)
+                self.do_cherry_pick(pull_request, release)
+
+    def do_cherry_pick(self, pull_request, release):
+        if not pull_request.is_merged:
+            pull_request.create_issue_comment(not_merged)
+
+        deprecation_message = (
+            "Support for automating cherry picks is being removed from spinnakerbot "
+            "in favor of the mergify backport command. To help with the transition, "
+            "I'll run the required command for you now, but in the future please "
+            "run the mergify command directly."
+        )
+        mergify_command = "@Mergifyio backport release-{}.x".format(release)
+        pull_request.create_issue_comment(deprecation_message)
+        pull_request.create_issue_comment(mergify_command)
+
+PullRequestCherryPickEventHandler()

--- a/manifests/deploy.yml
+++ b/manifests/deploy.yml
@@ -112,3 +112,4 @@ data:
           - spinnaker/spinnaker
           - spinnaker/spinnaker.github.io
       - name: pull_request_closed_event_handler
+      - name: pull_request_cherry_pick_event_handler


### PR DESCRIPTION
Adds back in `cherry-pick` and adds an alias `backport`, which reverts https://github.com/spinnaker/spinnaker.github.io/pull/1969. 

Soo.... @maggieneterval, @ezimanyi  it looks like @spinnakerbot is back doing cherry-picks! ![](https://emojis.slackmojis.com/emojis/images/1450475621/210/yay.gif?1450475621)


@plumpy and I were talking about how there wasn't any cherry-picks/backports found using when using the runbook's [cherry-pick open PRs query](https://github.com/pulls?utf8=%E2%9C%93&q=org%3Aspinnaker+is%3Apr+is%3Aopen+-base%3Amaster). For example, I had to search for `backport` directly and look thought them to find any missed ones, like https://github.com/spinnaker/igor/pull/762.


I thought https://github.com/spinnaker/spinnaker.github.io/pull/1952 would work, but then it occurred to me to try out a non Spinnaker org member. They couldn't mention `@ spinnaker/release-managers`, and I didn't get a notification. Example test case: https://github.com/spinnaker/spinnaker.github.io/pull/1969.


The [github docs](https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/changing-team-visibility) seem to suggest no, but it's not super explicit that public members can't.
> <kbd>![](https://user-images.githubusercontent.com/3469532/88241303-95b61c00-cc3e-11ea-9f94-521c378f6b11.png)</kbd>
