### PR TITLE
Pin google-cloud-secret-manager to 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 google
 pygithub>=1.40a
 pyyaml
-google-cloud-secret-manager
+google-cloud-secret-manager==1.0.0
 google-cloud-storage


### PR DESCRIPTION
There's a 2.0.0 version now that requires "substantial" changes: https://googleapis.dev/python/secretmanager/latest/UPGRADING.html