### PR TITLE
chore(repos): replace spinnaker.github.io with spinnaker.io

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -39,7 +39,7 @@ event:
     - spinnaker/halyard
     - spinnaker/spin
     - spinnaker/spinnaker
-    - spinnaker/spinnaker.github.io
+    - spinnaker/spinnaker.io
   handlers:
     - name: label_issue_comment_event_handler
     - name: issue_comment_assign_handler
@@ -51,17 +51,17 @@ event:
       config:
         omit_repos:
           - spinnaker/spinnaker
-          - spinnaker/spinnaker.github.io
+          - spinnaker/spinnaker.io
           - spinnaker/deck
           - spinnaker/spin
     - name: release_branch_pull_request_handler
       config:
         omit_repos:
           - spinnaker/spinnaker
-          - spinnaker/spinnaker.github.io
+          - spinnaker/spinnaker.io
     - name: master_branch_pull_request_handler
       config:
         omit_repos:
           - spinnaker/spinnaker
-          - spinnaker/spinnaker.github.io
+          - spinnaker/spinnaker.io
     - name: pull_request_closed_event_handler

--- a/manifests/deploy.yml
+++ b/manifests/deploy.yml
@@ -60,7 +60,7 @@ data:
     policy:
       repos:
       - spinnaker/spinnaker
-      - spinnaker/spinnaker.github.io
+      - spinnaker/spinnaker.io
       - spinnaker/deck-kayenta
       - spinnaker/kayenta
       - spinnaker/keel
@@ -70,7 +70,7 @@ data:
     event:
       repos:
       - spinnaker/spinnaker
-      - spinnaker/spinnaker.github.io
+      - spinnaker/spinnaker.io
       - spinnaker/clouddriver
       - spinnaker/deck
       - spinnaker/deck-kayenta
@@ -97,17 +97,17 @@ data:
         config:
           omit_repos:
           - spinnaker/spinnaker
-          - spinnaker/spinnaker.github.io
+          - spinnaker/spinnaker.io
           - spinnaker/deck
           - spinnaker/spin
       - name: release_branch_pull_request_handler
         config:
           omit_repos:
           - spinnaker/spinnaker
-          - spinnaker/spinnaker.github.io
+          - spinnaker/spinnaker.io
       - name: master_branch_pull_request_handler
         config:
           omit_repos:
           - spinnaker/spinnaker
-          - spinnaker/spinnaker.github.io
+          - spinnaker/spinnaker.io
       - name: pull_request_closed_event_handler


### PR DESCRIPTION
since spinnaker.github.io (the old docs site) is an archived/read-only repo.  spinnaker.io is the source of the current docs site.